### PR TITLE
Note taking and decision making

### DIFF
--- a/episodes/facilitation.md
+++ b/episodes/facilitation.md
@@ -171,40 +171,36 @@ For example, "Tina, please don't interrupt."
 For more actionable meeting facilitation strategies, we recommend checking out the Life Labs Learning two-page [Meeting Course-Correction Guide](https://www.lifelabslearning.com/book/download/meeting-course-corrections). 
 
 
-:::::::::::::::::::::::::::::::::::::: discussion
+:::::::::::::::::::::::::::::::::::::: challenge
 
-### Forming the Fellowship of the Ring
+### Catering Decisions (Take 1)
 
-#### Setting
-
-> You've just gotten back from a project kick-off meeting yesterday. It ran too long, the agenda seemed aimless and no-one stuck to it, and Gimli rambled for far too long on tangential topics. 
->
-> You're part of the RSE sub-team in the project, and you're determined that _your_ meetings will NOT be death-by-powerpoint and that Gimli will talk about as long as everyone else in the team, no longer.
->
-> Now you're _in_ the team meeting. Gimli is talking about the project tracker you should be using, and he's spent fifteen minutes explaining how good the Mithril Project manager (tm) is. Legolas would like to use the Lembas project tacking method, and you can't quite seem to get a word in edgewise. 
-
-#### Exercise
-
-- Discuss in small groups (or write down, if you're working solo): 
-  - What types of disruptions are these? See the NOAA resource for more different _types_ of disruptors and how to deal with them. 
-  - What might be a good way to handle this? 
-  - Assign the roles of Gimli and Legolas to two team members. Have a chair role-play how to redirect and defuse this type of difficult behaviour. 
+Pretend you are a participant at the short meeting segment recorded in this video.
+What disruptive behaviors do you notice?
+Does the facilitator make any attempts to address these disruptive behaviors? 
+If so, how?
+How do you feel at the end of this meeting?
 
 :::::::::::::: solution
 
-### What did we learn?
+Some disruptive behaviors that participants may notice are: 
 
-Thinking about the exercise: What went well? What was hard? Interrupting when a meeting isn't "going right" isn't easy, but it doesn't have to be hard. Some points to remember: 
+- Interrupting each other (a lot). 
+- One participant walking away from the desk without notice / answering a phone call during the meeting. 
+- No one raising hands. 
+- Being dismissive of others' concerns (around food allergy safety, vegetarian options). 
+- Eating on the call / talking with their mouth full. 
+- Not keeping microphone on mute when not speaking / coughing sounds.
+- General rudeness?
+- Trying to over-ride the group's decision after the meeting.
 
-- Address disruptions in two ways.
-  - At the time the disruption happens, make sure the behaviour is stopped.
-  - _After_ the meeting, make sure that you look at systemic ways to reduce that type of disruption as well - e.g. if you always run over time, consider assigning a standard "timekeeper" role to every meeting.
-- Practice can make it easier to interrupt, but **be aware of power dynamics**: it's one thing to stop a disagreement when you're chairing a meeting, but it might (or might not) be wise to interrupt someone who is in a much "higher" position in a hierarchy, if they aren't receptive to feedback.
-- If you _do_ have power or privilege (e.g. you're a chair, or you're a member of an in-group), make sure to use that power and privelege to support marginalised members. Sometimes it could be as simple as repeating what another person said and attributing it to the original speaker.
 
 ::::::::::::::
 
+
 ::::::::::::::::::::::::::::::::::::::
+
+
 
 :::::: keypoints
 

--- a/episodes/making_decisions.md
+++ b/episodes/making_decisions.md
@@ -6,14 +6,68 @@ exercises: 15
 
 :::::: questions
 
-* TBD
+* How can I make sure meetings end with important decisions having been made?
+* How do I harness participant's energy and opinions into concrete decision making?
+
 ::::::::::::::::
 
 
 :::::: objectives
 
 TBD
+
 ::::::::::::::::
+
+
+In most meetings, at least some agenda items will be ones on which decisions need to be made in order to keep work moving forward, or to meet deadlines.
+If none of the items on your agenda require decision making from the group, you should reconsider whether it is useful to have the meeting at all. 
+As discussed previously, information dissemination is usually not an appropriate reason to hold a meeting.
+Information can be circulated by email instead, without interrupting peoples' work. 
+
+Given that there are agenda items requiring decision-making, you should be clear about what the role of the meeting participants is in striking a decision.
+We go into depth in how to establish decision making roles and responsibilities in another course in this series (Collaboration on Remote Teams). 
+In brief, items placed on the agenda should be there because the participants at this meeting have some level of decision making role in their resolution. 
+That might be as an advisory body, or as an official body whose decisions are binding.
+The individuals at this meeting were invited because you believe that this group of people are likely to have useful insight and expertise in helping make these decisions.
+They may also be included because they will be impacted by the decision, and therefore have a stake in carrying it out.
+
+The difficulty of coming to consensus seems to raise exponentially with the number of meeting participants - so how can you ensure that decisions that need to be made actually get made and not deferred to a future meeting? 
+We recommend that meetings adopt a modified version of [Martha's Rules](https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1825&context=sociologyfacpub), which are designed to allow groups to make progress without requiring strict consensus. 
+
+
+## Martha's Rules and Culture
+
+The designers of Martha's Rules note that their success is dependent on the culture of the group implementing them. 
+In particular, successful implementation requires that participants be: 
+
+- Willing and able to listen to others, 
+- Trusting enough of the group to voice their opinions, 
+- Invested in the group's welfare and, 
+- Willing to adopt other's proposals in lieu of their own. 
+
+Our Collaboration on Remote Teams course delves into how team leaders can nurture these aspects of culture within their team, but some of the methods we've already discussed in this course go a long way towards establishing this culture.
+For instance, participants will be more willing to listen to others if they know that their right to share their opinion is being safeguarded by the Facilitator. 
+Martha's Rules also call for agenda items to be set and shared in advance of the meeting, and for each to have an associated time limit. 
+You're already well prepared for those elements!
+
+## The Steps
+
+
+
+:::::: challenge
+
+## Evaluating Multiple Proposals
+
+Exercise about implementing Martha's Rules - could we use the table from the publication and ask the group which proposals should move forward to the next stage?
+
+:::::: solution
+
+Solution text here.
+
+
+:::::::::::::::::::::::::::::::::::: 
+
+:::::::::::::::::: 
 
 
 

--- a/episodes/making_decisions.md
+++ b/episodes/making_decisions.md
@@ -52,7 +52,15 @@ You're already well prepared for those elements!
 
 ## The Steps
 
+There are five steps to Martha's rules, although the designers note that these five steps do not need to be followed exactly, and should be modified based on the group's needs. The five steps are: 
 
+1) Preparation, 
+2) Generating proposals, 
+3) Making proposals concrete, 
+4) Taking a "sense" vote, and 
+5) Taking a "vote" vote.
+
+We've already covered the preparation steps, so let's talk about generating proposals.  
 
 :::::: challenge
 

--- a/episodes/note_taking.md
+++ b/episodes/note_taking.md
@@ -13,14 +13,69 @@ exercises: 15
 
 :::::: objectives
 
-TBD
+At the end of this episode, participants will be able to...
+
+- Succinctly capture decisions, action items, owners, and deadlines in meeting notes. 
+- 
+
 ::::::::::::::::
 
 
+So you've been designated the Notetaker for a meeting - what does that mean? 
+Do you need to try to type every word that is spoken?
+How do you make sure you're capturing the right information? 
+To answer this question, it's useful to first focus on what the goal(s) are for having a Notetaker, which are (at least) two-fold: 
+
+- Make a record of decisions that were made, and any significant dissent that was raised.
+- Keep track of any follow-up action items (including who is responsible for them and what the deadlines are!). 
+
+Depending on the formality of the meeting (e.g. a Board meeting), you may also have an obligation to provide an official record of the meeting, who attended, and what was discussed and decided.
 
 
+## Why Your Notetaker Should be a Human
+
+You may be wondering why you should bother to take notes at all.
+After all, most, if not all, video conferencing systems now enable automated note taking with AI tools.
+The makers of these tools claim they can capture conversations, record action items, and circulate meeting notes to participants, without you having to do any of the work!
+Although these tools are becoming more popular, we strongly advise against relying on them, and urge careful consideration before deciding to use them in your meetings at all.
+There are a number of reasons to instead trust your note taking duties to a human, including security and privacy, quality, and usefulness of the resulting notes. 
+
+### Security and Privacy
+
+- AI notetakers expose your meeting data to the company that owns the tool (problems for confidentiality)
+- Some of these issues are issues of *accuracy* but others are issues of *usefulness*. If your AI tool is going to capture everything said during the meeting, a human still needs to go through those notes and correct them or actionabilize them.
+- AI notetakers might also hallucinate things . . . 
 
 
+### Quality
+
+Because all AI tools are dependent on their training data, AI note takers often perform more poorly when speakers have accents different from the majority language community used for training.
+In effect, this means that meeting participants who are not native speakers of  
+
+- Better with regional variations in speech / accents
+- Humans know the technical terms / jargon your group is using (or if they don't they might ask a question instead of guessing!)
+
+### Usefulness
+
+- Better at filtering important information
+- Able to capture decision points
+- Can proactively clarify points of confusion for the record
+
+
+## Other
+
+- Requires critical engagement with the meeting!
+
+
+:::::::::::::::: callout
+
+## AI Notetakers and Accessibility
+
+Although we do not recommend relying on AI tools for record keeping, that doesn't mean AI notetakers are useless!
+AI notetakers can be useful tools, particularly for Deaf or Hard of Hearing individuals, and for people for whom the meeting language is not their primary language.
+We recommend allowing AI notetakers on a case-by-case basis if requested by a meeting participant for accessibility reasons.  
+
+:::::::::::::::::::::::::::
 
 :::::: keypoints
 

--- a/episodes/note_taking.md
+++ b/episodes/note_taking.md
@@ -87,6 +87,69 @@ We recommend allowing AI notetakers on a case-by-case basis if requested by a me
 ## How to Take Good Notes
 
 
+Let's dig more deeply into what kind of information should be recorded in your meeting notes. To get us started, let's test out your current note taking technique with an exercise. 
+
+:::::::::::::::: challenge
+
+## Catering Decisions (Take 2)
+
+As an individual, pretend you are the Notetaker for the short meeting segment recorded in this video. 
+Watch the recording one time only, and type out whatever information you think is important to be recorded in the notes.
+Share your notes with a partner and compare.
+What did you both agree was important?
+Were there any pieces of information that you captured that your partner didn't, or vice versa? 
+
+
+:::::::::::::::::::::::::::::::: solution
+
+
+A possible set of notes from this meeting might be: 
+
+- Erin: Options are food trucks or venue catering. Deadline to tell venue is end of the week.
+- Angelique: Food trucks had long lines and ran out of food.
+- Toby: Food trucks were really good. Venue options are boring.
+- Rob: Food trucks were good but allergy situation last year. Venue catering would have ingredients list. Safer. 
+- Angelique: Venue catering would require us to track orders. Complicated. 
+- Erin: No - venue catering is a set order in advance. 
+- Rob: What about vegetarian/vegan and gluten free options? 
+- Erin: Different set menus available. 
+- Toby: We don't need to decide on the exact order right now. 
+- Erin: Correct - just need to decide on venue vs. food trucks. 
+- Toby: In favor of food trucks. More variety and more interactive. 
+- Angelique: Overlap with Ramadan. Need take-away options. 
+- Rob: Agree with Angelique. Vote for venue catering. 
+- Erin: Three votes for venue option. That's what we're doing. Need vegetarian opinion on final order. 
+- Angelique: Want to help decide final menu. 
+- Erin: Will tell the venue we're using their catering. Will send Angelique and Rob menu options. Get choices back to me by Tuesday?
+- Rob: Busy week - can't look at whole menu set. 
+- Angelique: Can narrow down the options and send to you to review. 
+- Rob: Ok!
+- Erin: Adjourns meeting. 
+
+Action items: 
+
+- Notify venue will use their catering for the conference. (Erin, by end of week)
+- Send Angelique all menu options in our budget. (Erin, asap)
+- Narrow down option list and send to Rob for final selections. (Angelique, ?)
+- Send final choices to Erin. (Rob, Tuesday?)
+
+
+::::::::::::::::::::::::::::::::::::::::::
+
+
+:::::::::::::::::::::::::::
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
+
+## Instructor Note
+
+Participants who are really paying attention may notice that the deadlines for all of the sub-tasks between Erin's "I'll send you a list of menu options" and "Please get me your decisions by Tuesday" weren't discussed. 
+Angelique and Rob would need to coordinate outside of the meeting on when they need to complete their individual review steps. 
+They may also need to more explicitly decide who is sending the final menu selections to Erin. Depending on the complexity of the task, the number of intermediate steps, and how frequently these individuals work together, that may be fine, or you may want to detail these responsibilities during the meeting time. 
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 
 

--- a/episodes/note_taking.md
+++ b/episodes/note_taking.md
@@ -32,6 +32,16 @@ To answer this question, it's useful to first focus on what the goal(s) are for 
 
 Depending on the formality of the meeting (e.g. a Board meeting), you may also have an obligation to provide an official record of the meeting, who attended, and what was discussed and decided.
 
+:::::: callout
+
+## Note Taking in Public
+
+We strongly recommend that note taking for your meetings take place in a document that is accessible to everyone invited to the meeting (for example a shared Google doc). 
+If everyone can see notes being taken in real time, the Notetaker will be motivated to actually take notes.
+In addition, other participants will be able to help out by adding information that is missed, or correcting a point they made if they notice it being misrepresented in the notes.
+
+
+::::::::::::::::
 
 ## Why Your Notetaker Should be a Human
 
@@ -87,7 +97,8 @@ We recommend allowing AI notetakers on a case-by-case basis if requested by a me
 ## How to Take Good Notes
 
 
-Let's dig more deeply into what kind of information should be recorded in your meeting notes. To get us started, let's test out your current note taking technique with an exercise. 
+Let's dig more deeply into what kind of information should be recorded in your meeting notes. 
+To get us started, let's test out your current note taking technique with an exercise. 
 
 :::::::::::::::: challenge
 
@@ -150,12 +161,32 @@ They may also need to more explicitly decide who is sending the final menu selec
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
+You and your partner may have captured different levels of detail, and that's ok!
+Hopefully, you both identified most of the following key elements: 
 
+- decisions reached (and vote counts if appropriate),
+- what follow-up actions were agreed upon,
+- who is responsible for each action item, and
+- what the deadline is for their completion.
 
+Action items can either be collected into a list at the bottom of the meeting notes, or called to attention with special formatting (e.g. highlighting).
+Either way, they should be quickly findable by someone skimming the notes. 
+
+Additional items that are good to capture in the notes if possible include: 
+
+- major points of opposition or dissent, 
+- concerns, cautionary points, or alternative paths forward. 
+
+Meeting notes should also include the date and time of the meeting and a list of participants.
+This makes it easier to answer questions later that may arise about who the decision-makers were on a particular issue.
+If possible, end your meetings at least 5-10 minutes before the scheduled stop time.
+This gives your notetaker time to consolidate the action item list and gives everyone else a few minutes for a bio break before their next meeting.
+In our experience, very few people have ever been unhappy about a meeting ending early!
 
 
 :::::: keypoints
 
-TDB
+- There are several good reasons to dedicate human attention to producing good meeting notes. 
+- Notes shouldn't be a full transcript of the meeting, but rather an attempt to capture important elements like decisions and follow-up needed.
 
 ::::::::::::::::

--- a/episodes/note_taking.md
+++ b/episodes/note_taking.md
@@ -1,5 +1,5 @@
 ---
-title: Note taking
+title: Note Taking
 teaching: 30
 exercises: 15
 ---
@@ -7,6 +7,7 @@ exercises: 15
 :::::: questions
 
 * What information is important to capture during a meeting? 
+* Why are humans the best note takers?
 
 ::::::::::::::::
 
@@ -16,7 +17,7 @@ exercises: 15
 At the end of this episode, participants will be able to...
 
 - Succinctly capture decisions, action items, owners, and deadlines in meeting notes. 
-- 
+- Describe why human-curated notes are worth investing effort into.
 
 ::::::::::::::::
 
@@ -35,36 +36,41 @@ Depending on the formality of the meeting (e.g. a Board meeting), you may also h
 ## Why Your Notetaker Should be a Human
 
 You may be wondering why you should bother to take notes at all.
-After all, most, if not all, video conferencing systems now enable automated note taking with AI tools.
+After all, most, if not all, video conferencing systems now enable automated note taking with GenAI tools.
 The makers of these tools claim they can capture conversations, record action items, and circulate meeting notes to participants, without you having to do any of the work!
 Although these tools are becoming more popular, we strongly advise against relying on them, and urge careful consideration before deciding to use them in your meetings at all.
 There are a number of reasons to instead trust your note taking duties to a human, including security and privacy, quality, and usefulness of the resulting notes. 
 
 ### Security and Privacy
 
-- AI notetakers expose your meeting data to the company that owns the tool (problems for confidentiality)
-- Some of these issues are issues of *accuracy* but others are issues of *usefulness*. If your AI tool is going to capture everything said during the meeting, a human still needs to go through those notes and correct them or actionabilize them.
-- AI notetakers might also hallucinate things . . . 
+Although these points have been made in many other venues, it bears repeating that commercially available AI note taking software is a commercial product, built to make money for its creators.
+Depending on the terms of service for a particular platform, this often means that your meeting data, including the whole meeting transcript, is exposed to the company that owns the tool. 
+This can raise significant issues for confidentiality, data ownership, and copyright.
+Enabling AI note-taking agents on your video calls can also lead to situations where meeting transcripts, summaries, or recordings are automatically sent to meeting participants, invitees, or mailing lists - including un-official pre- or post-meeting discussions that may have been "off the record"!
 
 
 ### Quality
 
 Because all AI tools are dependent on their training data, AI note takers often perform more poorly when speakers have accents different from the majority language community used for training.
-In effect, this means that meeting participants who are not native speakers of  
+In effect, this means that meeting participants who are not native speakers of American or British English will be disadvantaged by many popular AI notetakers.
+The note taking tool may "mishear" a word, phrase, or entire sentence and backfill that information with probabilistic slop.  
+A note taking tool is also likely to make mistakes in capturing technical terms, field-specific jargon, or company internal terminology, and again, will make up filler to compensate.
+A human note taker is more likely to ask questions when they are uncertain about what has been said!
 
-- Better with regional variations in speech / accents
-- Humans know the technical terms / jargon your group is using (or if they don't they might ask a question instead of guessing!)
 
 ### Usefulness
 
-- Better at filtering important information
-- Able to capture decision points
-- Can proactively clarify points of confusion for the record
+With the exception of a few very specialised types of meetings, notes should not be a transcript of the meeting.
+Instead, they should be a record that clearly and concisely lays out the important points of conversation, decisions made, and action steps needing follow up.
+An attentive meeting participant is much more capable of extracting meaning from a conversation. 
+Humans are also more likely to correctly identify things like sarcasm, irony, and meaning-laden pauses and therefore to avoid recording a sarcastic comment as a serious decision. 
+Furthermore, if note taking is socialised as a shared responsibility within your meeting group's culture, other participants are more likely to make corrections and clarifications to the notes in real time, when they notice the note taker has missed or misunderstood something. 
 
 
-## Other
+### Other
 
-- Requires critical engagement with the meeting!
+Building expectations around shared note taking responsibilities and norms not only gives you clearer, more actionable notes at the end of your meeting - it also ensures a baseline level of critical engagement during the meeting.
+At the very least, your note taker and backup need to be paying attention, and other meeting participants are likely to be paying enough attention to at least make sure their opinions are accurately captured in the notes!
 
 
 :::::::::::::::: callout
@@ -76,6 +82,14 @@ AI notetakers can be useful tools, particularly for Deaf or Hard of Hearing indi
 We recommend allowing AI notetakers on a case-by-case basis if requested by a meeting participant for accessibility reasons.  
 
 :::::::::::::::::::::::::::
+
+
+## How to Take Good Notes
+
+
+
+
+
 
 :::::: keypoints
 


### PR DESCRIPTION
This PR primarily adds content for the note taking and decision making episodes. I feel like the notetaking episode is fairly decently complete at this point, with the exception of adding a link to a video skit for one of the exercises. However, I might have spent too long belaboring the importance of human notetakers in this episode. Please let me know if it should be cut back.

I'm really struggling with the decision making episode. I wrote a long-winded introduction and then started to discuss Martha's Rules, but I got increasingly uncomfortable with detailing those out because we don't actually use Martha's Rules in Carpentries meetings. I certainly *can* describe how Martha's rules work ([using this reference](https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1825&context=sociologyfacpub)) if folks feels like this is the right direction to take, but I wanted to get a temperature check on the direction of the episode so far before committing. 

I've also proposed replacing the "Fellowship of the Ring" exercise with a group analysis of a recording of a phony "bad meeting" created by myself, @tobyhodges, @elletjies, and @froggleston. We're going to be doing a second take of the recording, so I haven't included that file in this PR. 